### PR TITLE
Add hostility beliefs regarding neighbouring civilisations

### DIFF
--- a/model.py
+++ b/model.py
@@ -268,7 +268,8 @@ class Civilisation(mesa.Agent):
                         f"> {self.tech_level:.3f})")
         else:
 
-            # TODO: update hostility beliefs after a failed attack
+            # update hostility beliefs after a failed attack
+            self.hostility_beliefs[attacker] = 1
             self.dprint(f"Attack failed ({attacker.tech_level:.3f}",
                         f"< {self.tech_level:.3f})")
                 


### PR DESCRIPTION
The implemented version is very basic, and not very rigorously derived. 

After observing a civilisation being destroyed, the updated hostility belief $\hat{h}_j$ regarding a neighbouring civilisation $j$ is given by  $h_j+c_j h_j/ \sum_k(c_k h_k) - h_j (c_j h_j / \sum_k(c_k h_k))$
where $c_j$ is an estimate of how capable the neighbour is deemed, $h_j$ is the prior hostility belief and the sum is over the neighbours.

After an unsuccessful attack, the target sets their belief regarding the attacker to 1.